### PR TITLE
Label encoder for the case where y is 1-D.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Version 0.1.*
 .. |Fix| replace:: :raw-html:`<span class="badge badge-danger">Fix</span>` :raw-latex:`{\small\sc [Fix]}`
 .. |API| replace:: :raw-html:`<span class="badge badge-warning">API Change</span>` :raw-latex:`{\small\sc [API Change]}`
 
+- |Feature| support class label encoding (`#18 <https://github.com/LAMDA-NJU/Deep-Forest/pull/18>`__) @NiMaZi
 - |Feature| support sample weight in :meth:`fit` (`#7 <https://github.com/LAMDA-NJU/Deep-Forest/pull/7>`__) @tczhao
 - |Feature| configurable predictor parameter (`#9 <https://github.com/LAMDA-NJU/Deep-Forest/issues/10>`__) @tczhao
 - |Enhancement| add base class ``BaseEstimator`` and ``ClassifierMixin`` (`#8 <https://github.com/LAMDA-NJU/Deep-Forest/pull/8>`__) @pjgao

--- a/deepforest/cascade.py
+++ b/deepforest/cascade.py
@@ -742,8 +742,15 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
         d["buffer"] = self.buffer_
         d["verbose"] = self.verbose
         d["use_predictor"] = self.use_predictor
+        
         if self.use_predictor:
             d["predictor_name"] = self.predictor_name
+            
+        # Save label encoder if labels are encoded.            
+        if hasattr(self, "labels_are_encoded"):
+            d["labels_are_encoded"] = self.labels_are_encoded
+            d["label_encoder"] = self.label_encoder_
+            
         _io.model_saveobj(dirname, "param", d)
         _io.model_saveobj(dirname, "binner", self.binners_)
         _io.model_saveobj(dirname, "layer", self.layers_, self.partial_mode)
@@ -779,6 +786,11 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
         self.partial_mode = d["partial_mode"]
         self.verbose = d["verbose"]
         self.use_predictor = d["use_predictor"]
+        
+        # Load label encoder if labels are encoded.
+        if "labels_are_encoded" in d:
+            self.labels_are_encoded = d["labels_are_encoded"]
+            self.label_encoder_ = d["label_encoder"]
 
         # Load internal containers
         self.binners_ = _io.model_loadobj(dirname, "binner")

--- a/deepforest/cascade.py
+++ b/deepforest/cascade.py
@@ -157,7 +157,6 @@ __model_doc = """
     partial_mode : :obj:`bool`, default=False
         Whether to train the deep forest in partial mode. For large
         datasets, it is recommended to use the partial mode.
-
         - If ``True``, the partial mode is activated and all fitted
           estimators will be dumped in a local buffer;
         - If ``False``, all fitted estimators are directly stored in the
@@ -174,7 +173,6 @@ __model_doc = """
           instance used by :mod:`np.random`.
     verbose : :obj:`int`, default=1
         Controls the verbosity when fitting and predicting.
-
         - If ``<= 0``, silent mode, which means no logging information will
           be displayed;
         - If ``1``, logging information on the cascade layer level will be
@@ -185,21 +183,17 @@ __model_doc = """
 
 __fit_doc = """
     .. note::
-
         Deep forest supports two kinds of modes for training:
-
         - **Full memory mode**, in which the training / testing data and
           all fitted estimators are directly stored in the memory.
         - **Partial mode**, in which after fitting each estimator using
           the training data, it will be dumped in the buffer. During the
           evaluating stage, the dumped estimators are reloaded into the
           memory sequentially to evaluate the testing data.
-
         By setting the ``partial_mode`` to ``True``, the partial mode is
         activated, and a local buffer will be created at the current
         directory. The partial mode is able to reduce the running memory
         cost when training the deep forest.
-
     Parameters
     ----------
     X : :obj:`numpy.ndarray` of shape (n_samples, n_features)
@@ -215,7 +209,6 @@ __fit_doc = """
 def deepforest_model_doc(header, item):
     """
     Decorator on obtaining documentation for deep forest models.
-
     Parameters
     ----------
     header: string
@@ -466,7 +459,6 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
     def predict(self, X):
         """
         Predict class labels or regression values for X.
-
         For classification, the predicted class for each sample in X is
         returned. For regression, the predicted value based on X is returned.
         """
@@ -716,15 +708,11 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
     def save(self, dirname="model"):
         """
         Save the model to the specified directory.
-
         Parameters
         ----------
         dirname : :obj:`str`, default="model"
             The name of the output directory.
-
-
         .. warning::
-
             Other methods on model serialization such as :mod:`pickle` or
             :mod:`joblib` are not recommended, especially when ``partial_mode``
             is set to ``True``.
@@ -742,15 +730,15 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
         d["buffer"] = self.buffer_
         d["verbose"] = self.verbose
         d["use_predictor"] = self.use_predictor
-        
+
         if self.use_predictor:
             d["predictor_name"] = self.predictor_name
-            
-        # Save label encoder if labels are encoded.            
+
+        # Save label encoder if labels are encoded.
         if hasattr(self, "labels_are_encoded"):
             d["labels_are_encoded"] = self.labels_are_encoded
             d["label_encoder"] = self.label_encoder_
-            
+
         _io.model_saveobj(dirname, "param", d)
         _io.model_saveobj(dirname, "binner", self.binners_)
         _io.model_saveobj(dirname, "layer", self.layers_, self.partial_mode)
@@ -763,15 +751,11 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
     def load(self, dirname):
         """
         Load the model from the specified directory.
-
         Parameters
         ----------
         dirname : :obj:`str`
             The name of the input directory.
-
-
         .. note::
-
             The dumped model after calling :meth:`load_model` is not exactly
             the same as the model before saving, because many objects
             irrelevant to model inference will not be saved.
@@ -786,7 +770,7 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
         self.partial_mode = d["partial_mode"]
         self.verbose = d["verbose"]
         self.use_predictor = d["use_predictor"]
-        
+
         # Load label encoder if labels are encoded.
         if "labels_are_encoded" in d:
             self.labels_are_encoded = d["labels_are_encoded"]
@@ -912,13 +896,11 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
     def predict_proba(self, X):
         """
         Predict class probabilities for X.
-
         Parameters
         ----------
         X : :obj:`numpy.ndarray` of shape (n_samples, n_features)
             The input samples. Internally, its dtype will be converted to
             ``np.uint8``.
-
         Returns
         -------
         proba : :obj:`numpy.ndarray` of shape (n_samples, n_classes)
@@ -990,13 +972,11 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
     def predict(self, X):
         """
         Predict class for X.
-
         Parameters
         ----------
         X : :obj:`numpy.ndarray` of shape (n_samples, n_features)
             The input samples. Internally, its dtype will be converted to
             ``np.uint8``.
-
         Returns
         -------
         y : :obj:`numpy.ndarray` of shape (n_samples,)

--- a/deepforest/cascade.py
+++ b/deepforest/cascade.py
@@ -807,6 +807,11 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
             random_state=random_state,
             verbose=verbose)
         
+        # Utility Variables
+        self.labels_are_encoded = False
+        self.type_of_target_ = none
+        self.label_encoder_ = none
+        
     def _encode_class_labels(self, y):
         """
         Docstring
@@ -815,7 +820,6 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
         from sklearn.utils.multiclass import type_of_target
         from sklearn.preprocessing import LabelEncoder
         
-        self.labels_are_encoded = False
         self.type_of_target_ = type_of_target(y)
         
         # Label encoder deals with full-mode. Partial-mode support is WIP.

--- a/deepforest/cascade.py
+++ b/deepforest/cascade.py
@@ -815,6 +815,26 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
     def _repr_performance(self, pivot):
         msg = "Val Acc = {:.3f} %"
         return msg.format(pivot * 100)
+    
+    def _map_any_k_to_v(a, k, v):
+        sidx = k.argsort()
+        k = k[sidx]
+        v = v[sidx]
+        idx = np.searchsorted(k,a.ravel()).reshape(a.shape)
+        idx[idx==len(k)] = 0
+        mask = k[idx] == a
+        return np.where(mask, v[idx], 0)
+
+    def _map_int_k_to_v(a, k, v):
+        m = np.zeros(k.max()+1,dtype=v.dtype)
+        m[k] = v
+        return m[a]
+        
+    def fit(self, X, y):
+        
+        self.o_label = np.unique(y)
+        self.e_label = np.arange(len(k))
+        super().fit(X, map_any_k_to_v(y, self.o_label, self.e_label))
 
     def predict_proba(self, X):
         """
@@ -907,4 +927,4 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
         """
         proba = self.predict_proba(X)
 
-        return np.argmax(proba, axis=1)
+        return map_any_k_to_v(np.argmax(proba, axis=1), self.e_label, self.o_label)

--- a/deepforest/cascade.py
+++ b/deepforest/cascade.py
@@ -841,7 +841,7 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
         if len(self.y_shape) == 1: 
             # Generate k-v pairs for the label encoding
             self.o_label = np.unique(y) 
-            self.e_label = np.arange(len(k))
+            self.e_label = np.arange(len(self.o_label))
 
             # If original labels are integers, then use the int version which is much faster
             if np.issubdtype(y.dtype, np.integer):
@@ -945,7 +945,7 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
         proba = self.predict_proba(X)
     
         # Decoder deals with 1-D target now. 2-D and above WIP.
-        if len(proba.shape) == 1:
+        if len(self.y_shape) == 1:
             
             # Encoded labels are always integers, so the int version mapper is applicable
             return _map_int_k_to_v(np.argmax(proba, axis=1), self.e_label, self.o_label)

--- a/deepforest/cascade.py
+++ b/deepforest/cascade.py
@@ -809,8 +809,8 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
         
         # Utility Variables
         self.labels_are_encoded = False
-        self.type_of_target_ = none
-        self.label_encoder_ = none
+        self.type_of_target_ = None
+        self.label_encoder_ = None
         
     def _encode_class_labels(self, y):
         """

--- a/deepforest/cascade.py
+++ b/deepforest/cascade.py
@@ -839,8 +839,13 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
         
         from sklearn.preprocessing import LabelEncoder
         
-        if self.labels_are_encoded:
-            decoded_y = self.label_encoder_.inverse_transform(y)
+        # Label encoder deals with full-mode. Partial-mode support is WIP.
+        if not self.partial_mode:
+            # Label encoder deals with single output, multi-class. Multi-output support is WIP.
+            if self.labels_are_encoded:
+                decoded_y = self.label_encoder_.inverse_transform(y)
+            else:
+                decoded_y = y
         else:
             decoded_y = y
             

--- a/deepforest/cascade.py
+++ b/deepforest/cascade.py
@@ -17,13 +17,13 @@ from ._binner import Binner
 
 def _map_any_k_to_v(a, k, v):
     """Helper function for mapping ndarray values based on k-v pair, where k can be of any dtype."""
-        sidx = k.argsort()
-        k = k[sidx]
-        v = v[sidx]
-        idx = np.searchsorted(k,a.ravel()).reshape(a.shape)
-        idx[idx==len(k)] = 0
-        mask = k[idx] == a
-        return np.where(mask, v[idx], 0)
+    sidx = k.argsort()
+    k = k[sidx]
+    v = v[sidx]
+    idx = np.searchsorted(k,a.ravel()).reshape(a.shape)
+    idx[idx==len(k)] = 0
+    mask = k[idx] == a
+    return np.where(mask, v[idx], 0)
 
 def _map_int_k_to_v(a, k, v):
     """Helper function for mapping ndarray values based on k-v pair, where k can only be of integers. This function is much faster than the 'any dtype' version."""

--- a/deepforest/cascade.py
+++ b/deepforest/cascade.py
@@ -813,27 +813,28 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
             partial_mode=partial_mode,
             n_jobs=n_jobs,
             random_state=random_state,
-            verbose=verbose)
-        
+            verbose=verbose,
+        )
+
         # Utility Variables
         self.labels_are_encoded = False
         self.type_of_target_ = None
         self.label_encoder_ = None
-        
+
     def _encode_class_labels(self, y):
         """
         Docstring
         """
-        
+
         from sklearn.utils.multiclass import type_of_target
         from sklearn.preprocessing import LabelEncoder
-        
+
         self.type_of_target_ = type_of_target(y)
-        
+
         # Label encoder deals with full-mode. Partial-mode support is WIP.
         if not self.partial_mode:
             # Label encoder deals with single output, multi-class. Multi-output support is WIP.
-            if self.type_of_target_ is 'binary' or 'multiclass':
+            if self.type_of_target_ is "binary" or "multiclass":
                 self.labels_are_encoded = True
                 self.label_encoder_ = LabelEncoder()
                 encoded_y = self.label_encoder_.fit_transform(y)
@@ -841,16 +842,16 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
                 encoded_y = y
         else:
             encoded_y = y
-            
+
         return encoded_y
-    
+
     def _decode_class_labels(self, y):
         """
         Docstring
         """
-        
+
         from sklearn.preprocessing import LabelEncoder
-        
+
         # Label encoder deals with full-mode. Partial-mode support is WIP.
         if not self.partial_mode:
             # Label encoder deals with single output, multi-class. Multi-output support is WIP.
@@ -860,19 +861,18 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
                 decoded_y = y
         else:
             decoded_y = y
-            
+
         return decoded_y
 
     def _repr_performance(self, pivot):
         msg = "Val Acc = {:.3f} %"
         return msg.format(pivot * 100)
-    
+
     def fit(self, X, y, sample_weight=None):
-        
+
         super().fit(
-            X=X, 
-            y=self._encode_class_labels(y),
-            sample_weight=sample_weight)
+            X=X, y=self._encode_class_labels(y), sample_weight=sample_weight
+        )
 
     def predict_proba(self, X):
         """

--- a/tests/test_model_input.py
+++ b/tests/test_model_input.py
@@ -13,22 +13,22 @@ def test_model_input_label_encoder():
     # Load data
     X, y = load_digits(return_X_y=True)
     y_as_str = np.char.add("label_", y.astype(str))
-    
+
     # Train model on integer labels
     # Labels should look like: 1, 2, 3, ...
     model = CascadeForestClassifier(random_state=1)
     model.fit(X, y)
     y_pred_int_labels = model.predict(X)
-    
+
     # Train model on string labels
     # Labels should look like: "label_1", "label_2", "label_3", ...
     model = CascadeForestClassifier(random_state=1)
     model.fit(X, y_as_str)
     y_pred_str_labels = model.predict(X)
-    
+
     # Check if the underlying data are the same
     y_pred_int_labels_as_str = np.char.add("label_", y_pred_int_labels.astype(str))
     assert_array_equal(y_pred_str_labels, y_pred_int_labels_as_str)
-    
+
     # Clean up buffer
     model.clean()

--- a/tests/test_model_input.py
+++ b/tests/test_model_input.py
@@ -4,10 +4,9 @@ from numpy.testing import assert_array_equal
 from sklearn.datasets import load_digits
 from deepforest import CascadeForestClassifier
 
+
 def test_model_input_label_encoder():
-    """
-    Test if the model behaves the same with and without label encoding.
-    """
+    """Test if the model behaves the same with and without label encoding."""
 
     # Load data
     X, y = load_digits(return_X_y=True)
@@ -24,7 +23,9 @@ def test_model_input_label_encoder():
     y_pred_str_labels = model.predict(X)
 
     # Check if the underlying data are the same
-    y_pred_int_labels_as_str = np.char.add("label_", y_pred_int_labels.astype(str))
+    y_pred_int_labels_as_str = np.char.add(
+        "label_", y_pred_int_labels.astype(str)
+    )
     assert_array_equal(y_pred_str_labels, y_pred_int_labels_as_str)
 
     # Clean up buffer

--- a/tests/test_model_input.py
+++ b/tests/test_model_input.py
@@ -2,7 +2,6 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from sklearn.datasets import load_digits
-
 from deepforest import CascadeForestClassifier
 
 def test_model_input_label_encoder():
@@ -14,14 +13,12 @@ def test_model_input_label_encoder():
     X, y = load_digits(return_X_y=True)
     y_as_str = np.char.add("label_", y.astype(str))
 
-    # Train model on integer labels
-    # Labels should look like: 1, 2, 3, ...
+    # Train model on integer labels. Labels should look like: 1, 2, 3, ...
     model = CascadeForestClassifier(random_state=1)
     model.fit(X, y)
     y_pred_int_labels = model.predict(X)
 
-    # Train model on string labels
-    # Labels should look like: "label_1", "label_2", "label_3", ...
+    # Train model on string labels. Labels should look like: "label_1", "label_2", "label_3", ...
     model = CascadeForestClassifier(random_state=1)
     model.fit(X, y_as_str)
     y_pred_str_labels = model.predict(X)

--- a/tests/test_model_input.py
+++ b/tests/test_model_input.py
@@ -1,0 +1,34 @@
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from sklearn.datasets import load_digits
+
+from deepforest import CascadeForestClassifier
+
+def test_model_input_label_encoder():
+    """
+    Test if the model behaves the same with and without label encoding.
+    """
+
+    # Load data
+    X, y = load_digits(return_X_y=True)
+    y_as_str = np.char.add("label_", y.astype(str))
+    
+    # Train model on integer labels
+    # Labels should look like: 1, 2, 3, ...
+    model = CascadeForestClassifier(random_state=1)
+    model.fit(X, y)
+    y_pred_int_labels = model.predict(X)
+    
+    # Train model on string labels
+    # Labels should look like: "label_1", "label_2", "label_3", ...
+    model = CascadeForestClassifier(random_state=1)
+    model.fit(X, y_as_str)
+    y_pred_str_labels = model.predict(X)
+    
+    # Check if the underlying data are the same
+    y_pred_int_labels_as_str = np.char.add("label_", y_pred_int_labels.astype(str))
+    assert_array_equal(y_pred_str_labels, y_pred_int_labels_as_str)
+    
+    # Clean up buffer
+    model.clean()


### PR DESCRIPTION
Resolved issue #13 

This is a very naive label encoder implemented with `sklearn.preprocessing.LabelEncoder`

- [x] single output (1-D) partial mode
- [x] single output (1-D) full mode
- [x] unit test