### PR TITLE
[FIX] Fix accepted data type on binning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Version 0.1.*
 .. |Fix| replace:: :raw-html:`<span class="badge badge-danger">Fix</span>` :raw-latex:`{\small\sc [Fix]}`
 .. |API| replace:: :raw-html:`<span class="badge badge-warning">API Change</span>` :raw-latex:`{\small\sc [API Change]}`
 
+- |Fix| fix accepted data types on the :obj:`binner` (`#23 <https://github.com/LAMDA-NJU/Deep-Forest/pull/23>`__) @xuyxu
 - |Feature| implement the :meth:`get_forest` method for efficient indexing (`#22 <https://github.com/LAMDA-NJU/Deep-Forest/pull/22>`__) @xuyxu
 - |Feature| support class label encoding (`#18 <https://github.com/LAMDA-NJU/Deep-Forest/pull/18>`__) @NiMaZi
 - |Feature| support sample weight in :meth:`fit` (`#7 <https://github.com/LAMDA-NJU/Deep-Forest/pull/7>`__) @tczhao

--- a/deepforest/_binner.py
+++ b/deepforest/_binner.py
@@ -9,8 +9,8 @@ This class is modified from:
 __all__ = ["Binner"]
 
 import numpy as np
-from sklearn.utils import check_random_state
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils import check_random_state, check_array
 
 from . import _cutils as _LIB
 
@@ -162,7 +162,9 @@ class Binner(TransformerMixin, BaseEstimator):
                 msg.format(self.n_bins_non_missing_.shape[0], X.shape[1])
             )
 
+        X = check_array(X, dtype=X_DTYPE, force_all_finite=False)
         X_binned = np.zeros_like(X, dtype=X_BINNED_DTYPE, order="F")
+
         _LIB._map_to_bins(
             X, self.bin_thresholds_, self.missing_values_bin_idx_, X_binned
         )

--- a/deepforest/_cutils.pyx
+++ b/deepforest/_cutils.pyx
@@ -74,11 +74,11 @@ cpdef _map_to_bins(object X,
     """
     cdef:
         const X_DTYPE_C[:, :] X_ndarray = X
-        SIZE_t n_features = X_ndarray.shape[1]
+        SIZE_t n_features = X.shape[1]
         SIZE_t feature_idx
 
     for feature_idx in range(n_features):
-        _map_num_col_to_bins(X[:, feature_idx],
+        _map_num_col_to_bins(X_ndarray[:, feature_idx],
                              binning_thresholds[feature_idx],
                              missing_values_bin_idx,
                              binned[:, feature_idx])


### PR DESCRIPTION
Resolves issue #20.

The accepted type of binning is `X_DTYPE_C` (i.e., `np.float64`), which is too strict.

This PR relaxes the restrictions via conducting an internal conversion on the data type using `check_array`.