### PR TITLE
[ENH] Add the sklearn backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Version 0.1.*
 .. |Fix| replace:: :raw-html:`<span class="badge badge-danger">Fix</span>` :raw-latex:`{\small\sc [Fix]}`
 .. |API| replace:: :raw-html:`<span class="badge badge-warning">API Change</span>` :raw-latex:`{\small\sc [API Change]}`
 
+- |Feature| add scikit-learn backend (`#36 <https://github.com/LAMDA-NJU/Deep-Forest/pull/36>`__) @xuyxu
 - |Feature| add official support for Mac-OS (`#34 <https://github.com/LAMDA-NJU/Deep-Forest/pull/34>`__) @T-Allen-sudo
 - |Feature| support configurable criterion (`#28 <https://github.com/LAMDA-NJU/Deep-Forest/issues/28>`__) @tczhao
 - |Feature| support regression prediction (`#25 <https://github.com/LAMDA-NJU/Deep-Forest/issues/25>`__) @tczhao

--- a/deepforest/_estimator.py
+++ b/deepforest/_estimator.py
@@ -10,6 +10,13 @@ from .forest import (
     ExtraTreesRegressor,
 )
 
+from sklearn.ensemble import (
+    RandomForestClassifier as sklearn_RandomForestClassifier,
+    ExtraTreesClassifier as sklearn_ExtraTreesClassifier,
+    RandomForestRegressor as sklearn_RandomForestRegressor,
+    ExtraTreesRegressor as sklearn_ExtraTreesRegressor,
+)
+
 
 def make_classifier_estimator(
     name,
@@ -17,29 +24,54 @@ def make_classifier_estimator(
     n_trees=100,
     max_depth=None,
     min_samples_leaf=1,
+    backend="custom",
     n_jobs=None,
     random_state=None,
 ):
     # RandomForestClassifier
     if name == "rf":
-        estimator = RandomForestClassifier(
-            criterion=criterion,
-            n_estimators=n_trees,
-            max_depth=max_depth,
-            min_samples_leaf=min_samples_leaf,
-            n_jobs=n_jobs,
-            random_state=random_state,
-        )
+        if backend == "custom":
+            estimator = RandomForestClassifier(
+                criterion=criterion,
+                n_estimators=n_trees,
+                max_depth=max_depth,
+                min_samples_leaf=min_samples_leaf,
+                n_jobs=n_jobs,
+                random_state=random_state,
+            )
+        elif backend == "sklearn":
+            estimator = sklearn_RandomForestClassifier(
+                criterion=criterion,
+                n_estimators=n_trees,
+                max_depth=max_depth,
+                min_samples_leaf=min_samples_leaf,
+                bootstrap=True,
+                oob_score=True,
+                n_jobs=n_jobs,
+                random_state=random_state,
+            )
     # ExtraTreesClassifier
     elif name == "erf":
-        estimator = ExtraTreesClassifier(
-            criterion=criterion,
-            n_estimators=n_trees,
-            max_depth=max_depth,
-            min_samples_leaf=min_samples_leaf,
-            n_jobs=n_jobs,
-            random_state=random_state,
-        )
+        if backend == "custom":
+            estimator = ExtraTreesClassifier(
+                criterion=criterion,
+                n_estimators=n_trees,
+                max_depth=max_depth,
+                min_samples_leaf=min_samples_leaf,
+                n_jobs=n_jobs,
+                random_state=random_state,
+            )
+        elif backend == "sklearn":
+            estimator = sklearn_ExtraTreesClassifier(
+                criterion=criterion,
+                n_estimators=n_trees,
+                max_depth=max_depth,
+                min_samples_leaf=min_samples_leaf,
+                bootstrap=True,
+                oob_score=True,
+                n_jobs=n_jobs,
+                random_state=random_state,
+            )
     else:
         msg = "Unknown type of estimator, which should be one of {{rf, erf}}."
         raise NotImplementedError(msg)
@@ -53,29 +85,54 @@ def make_regressor_estimator(
     n_trees=100,
     max_depth=None,
     min_samples_leaf=1,
+    backend="custom",
     n_jobs=None,
     random_state=None,
 ):
     # RandomForestRegressor
     if name == "rf":
-        estimator = RandomForestRegressor(
-            criterion=criterion,
-            n_estimators=n_trees,
-            max_depth=max_depth,
-            min_samples_leaf=min_samples_leaf,
-            n_jobs=n_jobs,
-            random_state=random_state,
-        )
+        if backend == "custom":
+            estimator = RandomForestRegressor(
+                criterion=criterion,
+                n_estimators=n_trees,
+                max_depth=max_depth,
+                min_samples_leaf=min_samples_leaf,
+                n_jobs=n_jobs,
+                random_state=random_state,
+            )
+        elif backend == "sklearn":
+            estimator = sklearn_RandomForestRegressor(
+                criterion=criterion,
+                n_estimators=n_trees,
+                max_depth=max_depth,
+                min_samples_leaf=min_samples_leaf,
+                bootstrap=True,
+                oob_score=True,
+                n_jobs=n_jobs,
+                random_state=random_state,
+            )
     # ExtraTreesRegressor
     elif name == "erf":
-        estimator = ExtraTreesRegressor(
-            criterion=criterion,
-            n_estimators=n_trees,
-            max_depth=max_depth,
-            min_samples_leaf=min_samples_leaf,
-            n_jobs=n_jobs,
-            random_state=random_state,
-        )
+        if backend == "custom":
+            estimator = ExtraTreesRegressor(
+                criterion=criterion,
+                n_estimators=n_trees,
+                max_depth=max_depth,
+                min_samples_leaf=min_samples_leaf,
+                n_jobs=n_jobs,
+                random_state=random_state,
+            )
+        elif backend == "sklearn":
+            estimator = sklearn_ExtraTreesRegressor(
+                criterion=criterion,
+                n_estimators=n_trees,
+                max_depth=max_depth,
+                min_samples_leaf=min_samples_leaf,
+                bootstrap=True,
+                oob_score=True,
+                n_jobs=n_jobs,
+                random_state=random_state,
+            )
     else:
         msg = "Unknown type of estimator, which should be one of {{rf, erf}}."
         raise NotImplementedError(msg)
@@ -91,6 +148,7 @@ class Estimator(object):
         n_trees=100,
         max_depth=None,
         min_samples_leaf=1,
+        backend="custom",
         n_jobs=None,
         random_state=None,
         is_classifier=True,
@@ -104,6 +162,7 @@ class Estimator(object):
                 n_trees,
                 max_depth,
                 min_samples_leaf,
+                backend,
                 n_jobs,
                 random_state,
             )
@@ -114,6 +173,7 @@ class Estimator(object):
                 n_trees,
                 max_depth,
                 min_samples_leaf,
+                backend,
                 n_jobs,
                 random_state,
             )

--- a/deepforest/_layer.py
+++ b/deepforest/_layer.py
@@ -52,6 +52,7 @@ class Layer(object):
         n_trees=100,
         max_depth=None,
         min_samples_leaf=1,
+        backend="custom",
         partial_mode=False,
         buffer=None,
         n_jobs=None,
@@ -66,6 +67,7 @@ class Layer(object):
         self.n_trees = n_trees
         self.max_depth = max_depth
         self.min_samples_leaf = min_samples_leaf
+        self.backend = backend
         self.partial_mode = partial_mode
         self.buffer = buffer
         self.n_jobs = n_jobs
@@ -95,6 +97,7 @@ class Layer(object):
             n_trees=self.n_trees,
             max_depth=self.max_depth,
             min_samples_leaf=self.min_samples_leaf,
+            backend=self.backend,
             n_jobs=self.n_jobs,
             random_state=random_state,
             is_classifier=self.is_classifier,

--- a/deepforest/cascade.py
+++ b/deepforest/cascade.py
@@ -235,6 +235,10 @@ __classifier_model_doc = """
         Specifying this will extend/overwrite the original parameters inherit
         from deep forest. If ``use_predictor`` is False, this parameter will
         have no effect.
+    backend : :obj:`{"custom", "sklearn"}`, default="custom"
+        The backend of the forest estimator. Supported backends are ``custom``
+        for higher time and memory efficiency and ``sklearn`` for additional
+        functionality.
     n_tolerant_rounds : :obj:`int`, default=2
         Specify when to conduct early stopping. The training process
         terminates when the validation performance on the training set does
@@ -345,6 +349,10 @@ __regressor_model_doc = """
         Specifying this will extend/overwrite the original parameters inherit
         from deep forest.
         If ``use_predictor`` is False, this parameter will have no effect.
+    backend : :obj:`{"custom", "sklearn"}`, default="custom"
+        The backend of the forest estimator. Supported backends are ``custom``
+        for higher time and memory efficiency and ``sklearn`` for additional
+        functionality.
     n_tolerant_rounds : :obj:`int`, default=2
         Specify when to conduct early stopping. The training process
         terminates when the validation performance on the training set does
@@ -461,6 +469,7 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
         use_predictor=False,
         predictor="forest",
         predictor_kwargs={},
+        backend="custom",
         n_tolerant_rounds=2,
         delta=1e-5,
         partial_mode=False,
@@ -478,6 +487,7 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
         self.max_depth = max_depth
         self.min_samples_leaf = min_samples_leaf
         self.predictor_kwargs = predictor_kwargs
+        self.backend = backend
         self.n_tolerant_rounds = n_tolerant_rounds
         self.delta = delta
         self.partial_mode = partial_mode
@@ -607,6 +617,10 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
             msg = "max_layers = {} should be strictly positive."
             raise ValueError(msg.format(self.max_layers))
 
+        if not self.backend in ("custom", "sklearn"):
+            msg = "backend = {} should be one of {{custom, sklearn}}."
+            raise ValueError(msg.format(self.backend))
+
         if not self.n_tolerant_rounds > 0:
             msg = "n_tolerant_rounds = {} should be strictly positive."
             raise ValueError(msg.format(self.n_tolerant_rounds))
@@ -729,6 +743,7 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
             self._set_n_trees(0),
             self.max_depth,
             self.min_samples_leaf,
+            self.backend,
             self.partial_mode,
             self.buffer_,
             self.n_jobs,
@@ -805,6 +820,7 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
                 self._set_n_trees(layer_idx),
                 self.max_depth,
                 self.min_samples_leaf,
+                self.backend,
                 self.partial_mode,
                 self.buffer_,
                 self.n_jobs,
@@ -1134,6 +1150,7 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
         use_predictor=False,
         predictor="forest",
         predictor_kwargs={},
+        backend="custom",
         n_tolerant_rounds=2,
         delta=1e-5,
         partial_mode=False,
@@ -1154,6 +1171,7 @@ class CascadeForestClassifier(BaseCascadeForest, ClassifierMixin):
             use_predictor=use_predictor,
             predictor=predictor,
             predictor_kwargs=predictor_kwargs,
+            backend=backend,
             n_tolerant_rounds=n_tolerant_rounds,
             delta=delta,
             partial_mode=partial_mode,
@@ -1331,6 +1349,7 @@ class CascadeForestRegressor(BaseCascadeForest, RegressorMixin):
         use_predictor=False,
         predictor="forest",
         predictor_kwargs={},
+        backend="custom",
         n_tolerant_rounds=2,
         delta=1e-5,
         partial_mode=False,
@@ -1351,6 +1370,7 @@ class CascadeForestRegressor(BaseCascadeForest, RegressorMixin):
             use_predictor=use_predictor,
             predictor=predictor,
             predictor_kwargs=predictor_kwargs,
+            backend=backend,
             n_tolerant_rounds=n_tolerant_rounds,
             delta=delta,
             partial_mode=partial_mode,

--- a/tests/test_model_classifier.py
+++ b/tests/test_model_classifier.py
@@ -124,11 +124,13 @@ def test_model_properties_after_fitting():
     assert "`forest_type` should be one of" in str(excinfo.value)
 
 
-def test_model_workflow_partial_mode():
+@pytest.mark.parametrize("backend", ["custom", "sklearn"])
+def test_model_workflow_partial_mode(backend):
     """Run the workflow of deep forest with a local buffer."""
 
     case_kwargs = copy.deepcopy(kwargs)
     case_kwargs.update({"partial_mode": True})
+    case_kwargs.update({"backend": backend})
 
     model = CascadeForestClassifier(**case_kwargs)
     model.fit(X_train, y_train)
@@ -187,11 +189,13 @@ def test_model_sample_weight():
     model.clean()  # clear the buffer
 
 
-def test_model_workflow_in_memory():
+@pytest.mark.parametrize("backend", ["custom", "sklearn"])
+def test_model_workflow_in_memory(backend):
     """Run the workflow of deep forest with in-memory mode."""
 
     case_kwargs = copy.deepcopy(kwargs)
     case_kwargs.update({"partial_mode": False})
+    case_kwargs.update({"backend": backend})
 
     model = CascadeForestClassifier(**case_kwargs)
     model.fit(X_train, y_train)
@@ -219,6 +223,7 @@ def test_model_workflow_in_memory():
         (0, {"max_layers": 0}),
         (1, {"n_tolerant_rounds": 0}),
         (2, {"delta": -1}),
+        (3, {"backend": "unknown"}),
     ],
 )
 def test_model_invalid_training_params(param):
@@ -236,6 +241,8 @@ def test_model_invalid_training_params(param):
         assert "n_tolerant_rounds" in str(excinfo.value)
     elif param[0] == 2:
         assert "delta " in str(excinfo.value)
+    elif param[0] == 3:
+        assert "backend" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("predictor", ["forest", "xgboost", "lightgbm"])

--- a/tests/test_model_regressor.py
+++ b/tests/test_model_regressor.py
@@ -106,11 +106,13 @@ def test_model_properties_after_fitting():
     assert "already exists in the internal container" in str(excinfo.value)
 
 
-def test_model_workflow_partial_mode():
+@pytest.mark.parametrize("backend", ["custom", "sklearn"])
+def test_model_workflow_partial_mode(backend):
     """Run the workflow of deep forest with a local buffer."""
 
     case_kwargs = copy.deepcopy(kwargs)
     case_kwargs.update({"partial_mode": True})
+    case_kwargs.update({"backend": backend})
 
     model = CascadeForestRegressor(**case_kwargs)
     model.fit(X_train, y_train)
@@ -134,11 +136,13 @@ def test_model_workflow_partial_mode():
     shutil.rmtree(save_dir)
 
 
-def test_model_workflow_in_memory():
+@pytest.mark.parametrize("backend", ["custom", "sklearn"])
+def test_model_workflow_in_memory(backend):
     """Run the workflow of deep forest with in-memory mode."""
 
     case_kwargs = copy.deepcopy(kwargs)
     case_kwargs.update({"partial_mode": False})
+    case_kwargs.update({"backend": backend})
 
     model = CascadeForestRegressor(**case_kwargs)
     model.fit(X_train, y_train)
@@ -166,6 +170,7 @@ def test_model_workflow_in_memory():
         (0, {"max_layers": 0}),
         (1, {"n_tolerant_rounds": 0}),
         (2, {"delta": -1}),
+        (3, {"backend": "unknown"}),
     ],
 )
 def test_model_invalid_training_params(param):
@@ -183,6 +188,8 @@ def test_model_invalid_training_params(param):
         assert "n_tolerant_rounds" in str(excinfo.value)
     elif param[0] == 2:
         assert "delta " in str(excinfo.value)
+    elif param[0] == 3:
+        assert "backend" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("predictor", ["forest", "xgboost", "lightgbm"])

--- a/tests/test_tree regressor.py
+++ b/tests/test_tree regressor.py
@@ -64,8 +64,3 @@ def test_tree_fit_invalid_training_params():
     with pytest.raises(ValueError) as execinfo:
         tree.fit(X_binned, y)
     assert "max_depth must be greater than zero." in str(execinfo.value)
-
-
-if __name__ == "__main__":
-
-    test_tree_properties_after_fitting()


### PR DESCRIPTION
This PR adds the scikit-learn backend to support functionality like feature_importance, shap (#12). It is up to the users to decide which backend they want to use:
* `custom`: Use the internal implementation of forest for high time and memory efficiency
* `sklearn`: Use the scikit-learn version of forest for additional functionality