### PR TITLE
Fix raise error problem

### DIFF
--- a/deepforest/cascade.py
+++ b/deepforest/cascade.py
@@ -1598,7 +1598,7 @@ class CascadeForestRegressor(BaseCascadeForest, RegressorMixin):
 
     def _check_array_numeric(self, y):
         """Check the input numpy array y is all numeric."""
-        numeric_types = np.typecodes['AllInteger'] + np.typecodes["AllFloat"]
+        numeric_types = np.typecodes["AllInteger"] + np.typecodes["AllFloat"]
         if y.dtype.kind in numeric_types:
             return True
         else:

--- a/deepforest/cascade.py
+++ b/deepforest/cascade.py
@@ -578,7 +578,7 @@ class BaseCascadeForest(BaseEstimator, metaclass=ABCMeta):
                 "The layer index should be in the range [0, {}], but got {}"
                 " instead."
             )
-            raise ValueError(msg.format(self.n_layers_ - 1, layer_idx))
+            raise IndexError(msg.format(self.n_layers_ - 1, layer_idx))
 
         layer_key = "layer_{}".format(layer_idx)
 


### PR DESCRIPTION
Fix https://github.com/LAMDA-NJU/Deep-Forest/issues/87
By changing the error type raised in `__getitem__` from `ValueError` to `IndexError`, now the `CascadeForestRegressor()` and `CascadeForestClassifier()` object is a normal, iteratable iterator.