### PR TITLE
correct np.int to int. Numpy alias np.int has been deprecated

### DIFF
--- a/deepforest/forest.py
+++ b/deepforest/forest.py
@@ -200,7 +200,7 @@ def _partition_estimators(n_estimators, n_jobs):
 
     # Partition estimators between jobs
     n_estimators_per_job = np.full(
-        n_jobs, n_estimators // n_jobs, dtype=np.int
+        n_jobs, n_estimators // n_jobs, dtype=int
     )
     n_estimators_per_job[: n_estimators % n_jobs] += 1
     starts = np.cumsum(n_estimators_per_job)
@@ -563,7 +563,7 @@ class ForestClassifier(ClassifierMixin, BaseForest, metaclass=ABCMeta):
         self.classes_ = []
         self.n_classes_ = []
 
-        y_store_unique_indices = np.zeros(y.shape, dtype=np.int)
+        y_store_unique_indices = np.zeros(y.shape, dtype=int)
         for k in range(self.n_outputs_):
             classes_k, y_store_unique_indices[:, k] = np.unique(
                 y[:, k], return_inverse=True


### PR DESCRIPTION
minor correction: `np.int` to `int`.
Numpy alias np.int has been deprecated leading to error in the package.