### PR TITLE
Update _criterion.pxd

### DIFF
--- a/deepforest/tree/_criterion.pxd
+++ b/deepforest/tree/_criterion.pxd
@@ -46,10 +46,10 @@ cdef class Criterion:
     # Methods
     cdef int init(self, const DOUBLE_t[:, ::1] y, DOUBLE_t* sample_weight,
                   double weighted_n_samples, SIZE_t* samples, SIZE_t start,
-                  SIZE_t end) nogil except -1
-    cdef int reset(self) nogil except -1
-    cdef int reverse_reset(self) nogil except -1
-    cdef int update(self, SIZE_t new_pos) nogil except -1
+                  SIZE_t end) except -1 nogil
+    cdef int reset(self) except -1 nogil
+    cdef int reverse_reset(self) except -1 nogil
+    cdef int update(self, SIZE_t new_pos) except -1 nogil
     cdef double node_impurity(self) nogil
     cdef void children_impurity(self, double* impurity_left,
                                 double* impurity_right) nogil


### PR DESCRIPTION
The keyword 'nogil' should appear at the end of the function signature line. Placing it before 'except' or 'noexcept' will be disallowed in a future version of Cython.