### PR TITLE
Update _splitter.pxd

### DIFF
--- a/deepforest/tree/_splitter.pxd
+++ b/deepforest/tree/_splitter.pxd
@@ -74,12 +74,12 @@ cdef class Splitter:
                   np.ndarray X_idx_sorted=*) except -1
 
     cdef int node_reset(self, SIZE_t start, SIZE_t end,
-                        double* weighted_n_node_samples) nogil except -1
+                        double* weighted_n_node_samples) except -1 nogil
 
     cdef int node_split(self,
                         double impurity,   # Impurity of the node
                         SplitRecord* split,
-                        SIZE_t* n_constant_features) nogil except -1
+                        SIZE_t* n_constant_features) except -1 nogil
 
     cdef void node_value(self, double* dest) nogil
 


### PR DESCRIPTION
The keyword 'nogil' should appear at the end of the function signature line. Placing it before 'except' or 'noexcept' will be disallowed in a future version of Cython.