### PR TITLE
Update _utils.pxd

### DIFF
--- a/deepforest/tree/_utils.pxd
+++ b/deepforest/tree/_utils.pxd
@@ -37,7 +37,7 @@ ctypedef fused realloc_ptr:
     (StackRecord*)
     (PriorityHeapRecord*)
 
-cdef realloc_ptr safe_realloc(realloc_ptr* p, size_t nelems) nogil except *
+cdef realloc_ptr safe_realloc(realloc_ptr* p, size_t nelems) except * nogil
 
 
 cdef np.ndarray sizet_ptr_to_ndarray(SIZE_t* data, SIZE_t size)
@@ -75,7 +75,7 @@ cdef class Stack:
     cdef bint is_empty(self) nogil
     cdef int push(self, SIZE_t start, SIZE_t end, SIZE_t depth, SIZE_t parent,
                   bint is_left, double impurity,
-                  SIZE_t n_constant_features) nogil except -1
+                  SIZE_t n_constant_features) except -1 nogil
     cdef int pop(self, StackRecord* res) nogil
 
 
@@ -107,7 +107,7 @@ cdef class PriorityHeap:
     cdef int push(self, SIZE_t node_id, SIZE_t start, SIZE_t end, SIZE_t pos,
                   SIZE_t depth, bint is_leaf, double improvement,
                   double impurity, double impurity_left,
-                  double impurity_right) nogil except -1
+                  double impurity_right) except -1 nogil
     cdef int pop(self, PriorityHeapRecord* res) nogil
 
 # =============================================================================
@@ -125,9 +125,9 @@ cdef class WeightedPQueue:
     cdef WeightedPQueueRecord* array_
 
     cdef bint is_empty(self) nogil
-    cdef int reset(self) nogil except -1
+    cdef int reset(self) except -1 nogil
     cdef SIZE_t size(self) nogil
-    cdef int push(self, DOUBLE_t data, DOUBLE_t weight) nogil except -1
+    cdef int push(self, DOUBLE_t data, DOUBLE_t weight) except -1 nogil
     cdef int remove(self, DOUBLE_t data, DOUBLE_t weight) nogil
     cdef int pop(self, DOUBLE_t* data, DOUBLE_t* weight) nogil
     cdef int peek(self, DOUBLE_t* data, DOUBLE_t* weight) nogil
@@ -148,8 +148,8 @@ cdef class WeightedMedianCalculator:
                                        # = w[0] + w[1] + ... + w[k-1]
 
     cdef SIZE_t size(self) nogil
-    cdef int push(self, DOUBLE_t data, DOUBLE_t weight) nogil except -1
-    cdef int reset(self) nogil except -1
+    cdef int push(self, DOUBLE_t data, DOUBLE_t weight) except -1 nogil
+    cdef int reset(self) except -1 nogil
     cdef int update_median_parameters_post_push(
         self, DOUBLE_t data, DOUBLE_t weight,
         DOUBLE_t original_median) nogil


### PR DESCRIPTION
The keyword 'nogil' should appear at the end of the function signature line. Placing it before 'except' or 'noexcept' will be disallowed in a future version of Cython.