### PR TITLE
Update _cutils.pyx

### DIFF
--- a/deepforest/_cutils.pyx
+++ b/deepforest/_cutils.pyx
@@ -44,7 +44,7 @@ cpdef np.ndarray _c_sample_mask(const INT32_t [:] indices,
         SIZE_t n = indices.shape[0]
         SIZE_t sample_id
         np.ndarray[BOOL, ndim=1] sample_mask = np.zeros((n_samples,),
-                                                        dtype=np.bool)
+                                                        dtype=bool)
 
     with nogil:
         for i in range(n):


### PR DESCRIPTION
`np.bool` is a deprecated alias for `bool` in numpy